### PR TITLE
check for no root decomposition when updating toplogy

### DIFF
--- a/Oligotyping/lib/decomposer.py
+++ b/Oligotyping/lib/decomposer.py
@@ -389,11 +389,11 @@ class Decomposer:
         self.progress.new('Raw Topology')
         # main loop
         while 1:
-            self.decomposition_depth += 1
+
             if not len(self.node_ids_to_analyze):
                 self.progress.end()
                 break
-            
+            self.decomposition_depth += 1
             # following for loop will go through all nodes that are stored in
             # self.node_ids_to_analyze list. while those nodes are being decomposed,
             # new nodes will appear and need to be analyzed next round. following
@@ -564,7 +564,7 @@ class Decomposer:
         
         #finally:
         self.progress.end()
-        self.topology.update_final_nodes()
+        self.topology.update_final_nodes(decomposition_depth=self.decomposition_depth)
 
         self.run.info('num_raw_nodes', utils.pretty_print(len(self.topology.final_nodes)))
 
@@ -575,7 +575,7 @@ class Decomposer:
         self.progress.new('Refreshing the topology')
         self.progress.update('Updating final nodes...')
 
-        self.topology.update_final_nodes()
+        self.topology.update_final_nodes(decomposition_depth=self.decomposition_depth)
        
         dirty_nodes = []
         for node_id in self.topology.final_nodes:

--- a/Oligotyping/lib/topology.py
+++ b/Oligotyping/lib/topology.py
@@ -228,11 +228,14 @@ class Topology:
         return self.nodes[self.nodes[node_id].parent]
 
 
-    def update_final_nodes(self):
+    def update_final_nodes(self, decomposition_depth):
         self.alive_nodes = [n for n in sorted(self.nodes.keys()) if not self.nodes[n].killed]
 
         # get final nodes sorted by abundance        
-        final_nodes_tpls = [(self.nodes[n].size, n) for n in self.alive_nodes if not self.nodes[n].children]
+        final_nodes_tpls = [
+            (self.nodes[n].size, n) for n in self.alive_nodes if not self.nodes[n].children or (
+                    decomposition_depth == 0 and
+                    n == 'root')]
         final_nodes_tpls.sort(reverse = True)
         self.final_nodes = [n[1] for n in final_nodes_tpls]
 


### PR DESCRIPTION
Hi @meren,

I've made 3 minor changes.

1 - I moved the `self.decomposition_depth += 1` to after the `if not len(self.node_ids_to_analyze):` so that the decomposition depth is not incremented before this check has been made (else, upon exiting after no decomposition, it looks as though one round of decomposition was completed).

2 and 3 - I pass in the decomposition depth to the `update_final_nodes` method so that we can check for the specific instance where the nodes considered to be final nodes may be the root node, when no decomposition has occurred.

N.B. I have only run two tests and these tests only involve the actual decomposition and output of count tables. They do not  include figure generation etc.  I ran on a set of sequences that undergo decomposition in the expected manner. And I ran on a set of sequences that were causing me trouble (i.e. 0 decomposition of the root node). For the former, the results are exactly the same before and after my changes. For the latter, the changes fix the problem and the root node is included in the final nodes.

Given that I haven't tested the creation of figures etc., I'm more than happy for you not to include this commit - as you like. I run a stripped down version of your code in SymPortal to which I will make these changes so that I can keep running MED.

Thanks again for your help.

Ben

### Command run for testing:
```
oligotyping/decompose -M 12 -T --skip-gen-html --skip-gen-figures -R --skip-check-input-file -o results/  seqs_for_med_MesoF_ID469_clade_C.redundant.padded.fasta
```